### PR TITLE
Fix usage of option to run AVD headless

### DIFF
--- a/vars/withAvd.groovy
+++ b/vars/withAvd.groovy
@@ -5,7 +5,7 @@ def call(Map config, Closure steps) {
 
     String hardwareProfile = config.hardwareProfile
     String systemImage = config.systemImage
-    boolean headless = config.headless ?: true
+    boolean headless = config.containsKey('headless') ? config.headless : true
 
     if (hardwareProfile == null || systemImage == null) {
         failBuildWithError("hardwareProfile and systemImage must be provided for launching AVD")


### PR DESCRIPTION
With the current implementation, if the `headless` option is set to `false`, the Elvis operator will evaluate to the fallback value (`true`), so the AVD will be run in headless mode regardless of the option. The proposed fix falls back to `true` only if the `headless` option is not present in the `config` dictionary.