### PR TITLE
Update script for new versions of cmdline-tools

### DIFF
--- a/vars/checkSdkInstallation.groovy
+++ b/vars/checkSdkInstallation.groovy
@@ -1,0 +1,32 @@
+def call() {
+    if (env.ANDROID_SDK_ROOT == null && env.ANDROID_HOME == null) {
+        failBuildWithError("ANDROID_SDK_ROOT not defined, cannot launch AVD")
+    } else if (env.ANDROID_SDK_ROOT == null && env.ANDROID_HOME != null) {
+        // Compatibility with legacy
+        env.ANDROID_SDK_ROOT = env.ANDROID_HOME
+    }
+
+    if (env.ANDROID_CMDLINE_TOOLS_ROOT == null || !env.ANDROID_CMDLINE_TOOLS_ROOT.startsWith(env.ANDROID_SDK_ROOT)) {
+        echo "Checking command-line tools installation"
+        String cmdlineToolsRoot = "$ANDROID_SDK_ROOT/cmdline-tools/latest/"
+
+        boolean test = fileExists file: "$cmdlineToolsRoot/bin/sdkmanager"
+
+        if (!test) {
+            // Compatibilty with legacy
+            cmdlineToolsRoot = "$ANDROID_SDK_ROOT/tools/"
+            test = fileExists file: "$cmdlineToolsRoot/bin/sdkmanager"
+
+            if(!test) {
+                failBuildWithError("No Android SDK found at $ANDROID_SDK_ROOT/cmdline-tools/latest/")
+            }
+        }
+
+        env.ANDROID_CMDLINE_TOOLS_ROOT = cmdlineToolsRoot
+    }
+}
+
+private def failBuildWithError(String message) {
+    echo message
+    throw new IllegalStateException(message)
+}

--- a/vars/withAvd.groovy
+++ b/vars/withAvd.groovy
@@ -1,7 +1,5 @@
 def call(Map config, Closure steps) {
-    if (env.ANDROID_HOME == null) {
-        failBuildWithError("ANDROID_HOME not defined, cannot launch AVD")
-    }
+    checkSdkInstallation()
 
     String hardwareProfile = config.hardwareProfile
     String systemImage = config.systemImage
@@ -18,7 +16,7 @@ private def executeWithAvd(String hardwareProfile, String systemImage, boolean h
     def avdName = env.BUILD_TAG.replaceAll(/%20|%2F|\s/, "-")
     def emulatorSerial = null
     try {
-        installSystemImage(systemImage)
+        installAndroidSdkPackages([systemImage])
         createAvd(avdName, hardwareProfile, systemImage)
         emulatorSerial = launchAvd(avdName, headless)
 
@@ -34,15 +32,9 @@ private def executeWithAvd(String hardwareProfile, String systemImage, boolean h
     }
 }
 
-private def installSystemImage(String systemImage) {
-    echo "Installing Android system image $systemImage"
-    sh "$ANDROID_HOME/tools/bin/sdkmanager '$systemImage'"
-    sh "yes | $ANDROID_HOME/tools/bin/sdkmanager --licenses"
-}
-
 private def createAvd(String avdName, String hardwareProfile, String systemImage) {
     echo "Creating AVD $avdName"
-    sh "$ANDROID_HOME/tools/bin/avdmanager create avd -n $avdName -f -k '$systemImage' -d '$hardwareProfile' -c 100M"
+    sh "$ANDROID_CMDLINE_TOOLS_ROOT/bin/avdmanager create avd -n $avdName -f -k '$systemImage' -d '$hardwareProfile' -c 100M"
 }
 
 private def launchAvd(String avdName, boolean headless) {
@@ -53,16 +45,16 @@ private def launchAvd(String avdName, boolean headless) {
     echo "Launching AVD $avdName with serial $emulatorSerial"
 
     timeout(time: 5, unit: "MINUTES") {
-        sh "$ANDROID_HOME/emulator/emulator -avd $avdName -port $emulatorPort -memory 2048 -partition-size 1024 $noWindowFlag -no-boot-anim -no-audio -no-snapshot &"
-        sh "$ANDROID_HOME/platform-tools/adb -s $emulatorSerial wait-for-device"
+        sh "$ANDROID_SDK_ROOT/emulator/emulator -avd $avdName -port $emulatorPort -memory 2048 -partition-size 1024 $noWindowFlag -no-boot-anim -no-audio -no-snapshot &"
+        sh "$ANDROID_SDK_ROOT/platform-tools/adb -s $emulatorSerial wait-for-device"
         waitUntil {
-            def bootCompleted = sh(script: "$ANDROID_HOME/platform-tools/adb -s ${emulatorSerial} shell getprop sys.boot_completed", returnStdout: true)
+            def bootCompleted = sh(script: "$ANDROID_SDK_ROOT/platform-tools/adb -s ${emulatorSerial} shell getprop sys.boot_completed", returnStdout: true)
             return bootCompleted.trim() == "1"
         }
-        sh "$ANDROID_HOME/platform-tools/adb -s $emulatorSerial shell settings put global window_animation_scale 0"
-        sh "$ANDROID_HOME/platform-tools/adb -s $emulatorSerial shell settings put global transition_animation_scale 0"
-        sh "$ANDROID_HOME/platform-tools/adb -s $emulatorSerial shell settings put global animator_duration_scale 0"
-        sh "$ANDROID_HOME/platform-tools/adb -s $emulatorSerial shell input keyevent 82"
+        sh "$ANDROID_SDK_ROOT/platform-tools/adb -s $emulatorSerial shell settings put global window_animation_scale 0"
+        sh "$ANDROID_SDK_ROOT/platform-tools/adb -s $emulatorSerial shell settings put global transition_animation_scale 0"
+        sh "$ANDROID_SDK_ROOT/platform-tools/adb -s $emulatorSerial shell settings put global animator_duration_scale 0"
+        sh "$ANDROID_SDK_ROOT/platform-tools/adb -s $emulatorSerial shell input keyevent 82"
     }
 
     return emulatorSerial
@@ -78,8 +70,8 @@ private def firstAvailablePortInRange(start, end) {
 }
 
 private def deleteAvd(String avdName, String emulatorSerial) {
-    sh "$ANDROID_HOME/platform-tools/adb -s $emulatorSerial emu kill || true"
-    sh "$ANDROID_HOME/tools/bin/avdmanager delete avd -n $avdName || true"
+    sh "$ANDROID_SDK_ROOT/platform-tools/adb -s $emulatorSerial emu kill || true"
+    sh "$ANDROID_CMDLINE_TOOLS_ROOT/bin/avdmanager delete avd -n $avdName || true"
 }
 
 private def failBuildWithError(String message) {


### PR DESCRIPTION
This PR supports more recent versions of command-line tool which should now be installed in `<sdk>/cmdline-tools/latest` and the new environement variable name which is `ANDROID_SDK_ROOT`. `ANDROID_HOME` is deprecated (see https://developer.android.com/studio/command-line/variables#android_sdk_root). It is fully compatible with legacy, though.

It also now check what packages are already installed on system to prevent installing them at every call.